### PR TITLE
fix(build): Exclude ai-engine from backend Docker build

### DIFF
--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -8,6 +8,9 @@ __pycache__/
 .pytest_cache/
 .coverage
 
+# AI Engine
+ai-engine/
+
 # Virtual environments
 venv/
 env/


### PR DESCRIPTION
  The ai-engine directory was being incorrectly included in the Docker build context, causing an excessively large image and leading to deployment
  timeouts. This change adds the directory to .dockerignore to resolve the build failure.